### PR TITLE
Use backticks to escape repository name in build.sc

### DIFF
--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -36,12 +36,12 @@ jobs:
           SAFE_ORG=$(echo $ORG | sed 's/[^a-zA-Z0-9]//g' | tr '[:upper:]' '[:lower:]')
           GROUP="com.github.$SAFE_ORG"
 
-          # Modify NAME to replace '-' with '_'
-          MODIFIED_NAME=$(echo "$NAME" | tr '-' '_')
+          # Prepare wrapped name
+          WRAPPED_NAME="\`${NAME}\`"
 
           # Replace placeholders
           sed -i "s/%NAME%/$NAME/g" build.sbt README.md src/test/scala/gcd/*
-          sed -i "s/%NAME%/$MODIFIED_NAME/g" build.sc
+          sed -i "s/%NAME%/$WRAPPED_NAME/g" build.sc
           sed -i "s/%REPOSITORY%/${GITHUB_REPOSITORY/\//\\/}/g" README.md
           sed -i "s/%ORGANIZATION%/$GROUP/g" build.sbt
 

--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -36,8 +36,12 @@ jobs:
           SAFE_ORG=$(echo $ORG | sed 's/[^a-zA-Z0-9]//g' | tr '[:upper:]' '[:lower:]')
           GROUP="com.github.$SAFE_ORG"
 
+          # Modify NAME to replace '-' with '_'
+          MODIFIED_NAME=$(echo "$NAME" | tr '-' '_')
+
           # Replace placeholders
-          sed -i "s/%NAME%/$NAME/g" build.sbt build.sc README.md src/test/scala/gcd/*
+          sed -i "s/%NAME%/$NAME/g" build.sbt README.md src/test/scala/gcd/*
+          sed -i "s/%NAME%/$MODIFIED_NAME/g" build.sc
           sed -i "s/%REPOSITORY%/${GITHUB_REPOSITORY/\//\\/}/g" README.md
           sed -i "s/%ORGANIZATION%/$GROUP/g" build.sbt
 


### PR DESCRIPTION
If the repository name contains a '-', the CI/CD will fail because in the 'build.sc', the name of the object cannot include a '-'. So, I replaced it with a '_'.

![image](https://github.com/chipsalliance/chisel-template/assets/13383992/305ae6ea-e990-4756-938a-dcebbaf1e1fe)
