### PR TITLE
[ci] Switch to distro Verilator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  verilator-version: v5.022
-  verilator-install-dir: verilator-install
-
 jobs:
   ci:
     name: ci
@@ -29,30 +25,8 @@ jobs:
           apps: sbt
       - name: Setup Dependencies
         run: |
-          sudo apt-get install ccache
-      - name: Get Cached Verilator
-        id: get-cached-verilator
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.verilator-install-dir }}
-          key: verilator-${{ env.verilator-version }}
-      - name: Install Verilator
-        if: steps.get-cached-verilator.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get install git help2man perl python3 make autoconf g++ flex bison numactl perl-doc libfl-dev
-          git clone https://github.com/verilator/verilator
-          unset VERILATOR_ROOT
-          cd verilator
-          git checkout ${{ env.verilator-version  }}
-          autoconf
-          ./configure --prefix=$(pwd)/../${{ env.verilator-install-dir }}
-          make
-          make install
-      - name: Set PATH
-        run: |
-          echo "$(pwd)/${{ env.verilator-install-dir }}/bin" >> $GITHUB_PATH
-          echo VERILATOR_ROOT="$(pwd)/${{ env.verilator-install-dir }}/share/verilator" >> $GITHUB_ENV
-          ln -sf $(pwd)/${{ env.verilator-install-dir }}/bin/verilator_bin $(pwd)/${{ env.verilator-install-dir }}/share/verilator/verilator_bin
+          sudo apt-get install verilator
+          verilator --version
       - name: SBT Test
         run: sbt test
       - name: mill Test


### PR DESCRIPTION
This debumps slightly to `Verilator 5.020 2024-01-01 rev (Debian 5.020-1)` (from currently build from source v5.022) but it seems to work and is simpler, especially as an example for users. What do you think @seldridge?