### PR TITLE
Update build.mill

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -21,6 +21,7 @@ object %NAME% extends SbtModule { m =>
     "-deprecation",
     "-feature",
     "-Xcheckinit",
+    "-Ymacro-annotations",
   )
   override def ivyDeps = Agg(
     ivy"org.chipsalliance::chisel:7.0.0-RC1",


### PR DESCRIPTION
Needed for the example in https://www.chisel-lang.org/docs/cookbooks/hierarchy to work. @public is a macro, but mill doesn't expand it, and sbt does. Hence, sbt worked but mill did not.